### PR TITLE
Support to AWS CLI V2 and WAF V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 The code is inspired by https://github.com/anthonymartin/aws-acl-fail2ban which bans/unbans IPs using AWS Network ACL.
 
-# fail2ban-aws-waf
+# fail2ban-aws-wafv2
 
 This package includes a script and fail2ban configuration that allows you to use fail2ban when utilizing AWS elastic load balancer (ELB) and an Nginx webserver. It is useful to protect your site against DoS and brute force attacks when behind a reverse proxy load balancer like ELB. Special consideration is required when using ELB with fail2ban because ELB only forwards the client IP to the server in an X-Forwarded-For header. Following this guide will enable you to use ELB, Nginx webservers and AWS WAF together with fail2ban for an dynamic firewall solution.
 The code in this repository is rewritten in Python and uses AWS WAF IP Conditions to ban/unban IP from fail2ban.

--- a/fail2ban/action.d/aws-waf.conf
+++ b/fail2ban/action.d/aws-waf.conf
@@ -13,7 +13,7 @@
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = python /path/to/fail2ban_aws_waf.py --ip-set-id AWS_WAF_IP_SET_ID --action ban --ip <ip> --logpath /full/path/to/log/dir --jail-name <name>
+actionban = python /path/to/fail2ban_aws_waf.py --ip-set-name AWS_WAF_IP_SET_NAME --ip-set-id AWS_WAF_IP_SET_ID --action ban --ip <ip> --logpath /full/path/to/log/dir --jail-name <name>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -21,7 +21,7 @@ actionban = python /path/to/fail2ban_aws_waf.py --ip-set-id AWS_WAF_IP_SET_ID --
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = python /path/to/fail2ban_aws_waf.py --ip-set-id AWS_WAF_IP_SET_ID --action unban --ip <ip> --logpath /full/path/to/log/dir --jail-name <name>
+actionunban = python /path/to/fail2ban_aws_waf.py --ip-set-name AWS_WAF_IP_SET_NAME --ip-set-id AWS_WAF_IP_SET_ID --action unban --ip <ip> --logpath /full/path/to/log/dir --jail-name <name>
 
 actionstart = 
 actioncheck =


### PR DESCRIPTION
Hi! I am using WAF V2 to block requests using ipset, like your project, but your python script only supports waf v1 so I updated it. Feel free to create a tag to keep support to both versions

Another thing kind offtopic, for ``x-forward-for`` in nginx behind Cloudfront I've created this bash:
```bash
#!/bin/bash

curl https://ip-ranges.amazonaws.com/ip-ranges.json | \
   jq -r '.prefixes[] | select(.service=="CLOUDFRONT") | .ip_prefix' | \
   xargs -I '{}' echo 'set_real_ip_from {};' > /etc/nginx/conf.d/cloudfront.conf && \
   echo 'real_ip_header X-Forwarded-For;' >> /etc/nginx/conf.d/cloudfront.conf && \
   echo 'real_ip_recursive on;' >> /etc/nginx/conf.d/cloudfront.conf 

nginx -t && /etc/init.d/nginx reload
```